### PR TITLE
Change CDN for jQuery to Cloudflare

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" type="text/css" href="style.css" />
 		<link rel="stylesheet" type="text/css" href="lib/spectrum.css" />
 		<script type="text/javascript" src="colorbrewer_schemes.js"></script>
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
 		<script src="lib/jquery.svg.min.js" type="text/javascript"></script>
 		<script src="lib/jquery.svgdom.min.js" type="text/javascript"></script>
 		<script type="text/javascript" src="lib/spectrum.min.js"></script>


### PR DESCRIPTION
Fixing this error by changing jQuery URL from GoogleAPIs to CloudFlare. Google stopped serving this through http, apparently!
``` Loading failed for the <script> with source “http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js”. ```

![Screenshot 2019-12-17 at 15 20 53](https://user-images.githubusercontent.com/10443203/71008667-e54ccc00-20e0-11ea-9c8b-1df0f91eafe9.png)
